### PR TITLE
Configure Pythia6 for TunedDIS branch

### DIFF
--- a/src/Physics/Hadronization/Pythia6Hadronization.cxx
+++ b/src/Physics/Hadronization/Pythia6Hadronization.cxx
@@ -311,7 +311,7 @@ TClonesArray *
          p->GetKF(),                // pdg
          GHepStatus_t(p->GetKS()),  // status
          p->GetParent(),            // first parent
-         0,                         // second parent
+         -1,                        // second parent
          p->GetFirstChild(),        // first daughter
          p->GetLastChild(),         // second daughter
          p->GetPx(),                // px

--- a/src/Physics/Hadronization/Pythia6Hadronization.cxx
+++ b/src/Physics/Hadronization/Pythia6Hadronization.cxx
@@ -75,11 +75,21 @@ void Pythia6Hadronization::ProcessEventRecord(GHepRecord * event) const
   Interaction * interaction = event->Summary();
   TClonesArray * particle_list = this->Hadronize(interaction);
 
-  GHepParticle * particle = 0;
+  int mom = event->FinalStateHadronicSystemPosition();
+  assert(mom!=-1);
+
+  GHepParticle * p = 0;
   TIter particle_iter(particle_list);
-  while ((particle = (GHepParticle *) particle_iter.Next())) 
+  while ((p = (GHepParticle *) particle_iter.Next())) 
   {
-     event->AddParticle(*particle);
+     p->SetFirstMother(mom + p->FirstMother());
+     p->SetLastMother(mom + p->LastMother());
+     int ifd = (p->FirstDaughter() == -1) ? -1 : mom + p->FirstDaughter();
+     int ild = (p->LastDaughter()  == -1) ? -1 : mom + p->LastDaughter();
+     p->SetFirstDaughter(ifd);
+     p->SetLastDaughter (ild);
+
+     event->AddParticle(*p);
   }
 }
 //____________________________________________________________________________
@@ -305,7 +315,27 @@ TClonesArray *
   TMCParticle * p = 0;
   TIter particle_iter(pythia_particles);
 
+  // Hadronic 4vec
+  TLorentzVector p4Had = kinematics.HadSystP4();
+
+  // Vector defining rotation from LAB to LAB' (z:= \vec{phad})
+  TVector3 unitvq = p4Had.Vect().Unit();
+
+  // Boost velocity LAB' -> HCM
+  TVector3 beta(0,0,p4Had.P()/p4Had.Energy());
+
   while( (p = (TMCParticle *) particle_iter.Next()) ) {
+     // The fragmentation products are generated in the hadronic CM frame
+     // where the z>0 axis is the \vec{phad} direction. For each particle 
+     // returned by the hadronizer:
+     // - boost it back to LAB' frame {z:=\vec{phad}} / doesn't affect pT
+     // - rotate its 3-momentum from LAB' to LAB
+     TLorentzVector p4o(p->GetPx(), p->GetPy(), p->GetPz(), p->GetEnergy());
+     p4o.Boost(beta); 
+     TVector3 p3 = p4o.Vect();
+     p3.RotateUz(unitvq); 
+     TLorentzVector p4(p3,p4o.Energy());
+
      // Convert from TMCParticle to GHepParticle
      GHepParticle particle = GHepParticle(
          p->GetKF(),                // pdg
@@ -314,10 +344,10 @@ TClonesArray *
          -1,                        // second parent
          p->GetFirstChild(),        // first daughter
          p->GetLastChild(),         // second daughter
-         p->GetPx(),                // px
-         p->GetPy(),                // py
-         p->GetPz(),                // pz
-         p->GetEnergy(),            // e
+         p4.Px(),                   // px
+         p4.Py(),                   // py
+         p4.Pz(),                   // pz
+         p4.Energy(),               // e
          p->GetVx(),                // x
          p->GetVy(),                // y
          p->GetVz(),                // z
@@ -338,11 +368,6 @@ TClonesArray *
             return 0;
         }
      }
-
-     // fix numbering scheme used for mother/daughter assignments
-     particle.SetFirstMother   (particle.FirstMother()   - 1);
-     particle.SetFirstDaughter (particle.FirstDaughter() - 1);
-     particle.SetLastDaughter  (particle.LastDaughter()  - 1);
 
      // insert the particle in the list
      new ( (*particle_list)[i++] ) GHepParticle(particle);

--- a/src/Physics/Hadronization/Pythia6Hadronization.h
+++ b/src/Physics/Hadronization/Pythia6Hadronization.h
@@ -23,6 +23,7 @@
 #include <TPythia6.h>
 
 #include "Framework/EventGen/EventRecordVisitorI.h"
+#include "Framework/Interaction/Interaction.h"
 #include "Framework/ParticleData/PDGCodeList.h" 
 
 namespace genie {


### PR DESCRIPTION
- Fixed missing include
- TMCParticle to GHepParticle converter needed when using Pythia6
- Need to boost hadronization products back into the LAB frame as this is no longer handled by DISHadronicSystemGenerator
- Fix the mother/daughter indexes of the hadronization products